### PR TITLE
Origin/related videos component

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -673,7 +673,7 @@ var instantClick
     InstantClick.on('change', function() {
       initializePage();
     });
-    InstantClick.init();
+    InstantClick.init('mousedown');
   }
 
 // INITIALIZE/ERROR HANDLING

--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -1,6 +1,16 @@
 @import 'variables';
 @import 'mixins';
 
+.related-videos {
+  display: flex;
+  justify-content: space-around;
+  width: 100%;
+
+  iframe {
+    width: 30%;
+  }
+}
+
 .stories-show {
   @include themeable(background, theme-background, $lightest-gray);
 }

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -220,6 +220,9 @@ class StoriesController < ApplicationController
     redirect_if_show_view_param
     return if performed?
 
+    Rails.cache.fetch("#{@article.id}-related-vidoes", expires_in: 12.hours) do
+      @related_videos = YouTubeService.video_info(@article.cached_tag_list_array)
+    end
     render template: "articles/show"
   end
 

--- a/app/decorators/article_decorator.rb
+++ b/app/decorators/article_decorator.rb
@@ -53,10 +53,6 @@ class ArticleDecorator < ApplicationDecorator
     published_at.to_i
   end
 
-  def related_videos
-    YouTubeService.video_info(cached_tag_list_array)
-  end
-
   def description_and_tags
     modified_description = description.strip
     modified_description += "." unless description.end_with?(".")

--- a/app/javascript/packs/homePage.jsx
+++ b/app/javascript/packs/homePage.jsx
@@ -130,4 +130,4 @@ InstantClick.on('receive', (address, body, title) => {
     title,
   };
 });
-InstantClick.init();
+InstantClick.init('mousedown');

--- a/app/javascript/packs/relatedVideos.jsx
+++ b/app/javascript/packs/relatedVideos.jsx
@@ -1,0 +1,20 @@
+import { h, render } from 'preact';
+import { RelatedVideos } from '../relatedVideos/RelatedVideos';
+
+function loadVideos() {
+  const root = document.getElementById('videos-container');
+  render(
+    <RelatedVideos videos={root.dataset.videos} />,
+    root,
+    root.firstElementChild,
+  );
+}
+
+document.ready.then(() => {
+  loadVideos();
+  window.InstantClick.on('change', () => {
+    if (document.getElementById('videos-container')) {
+      loadVideos();
+    }
+  });
+});

--- a/app/javascript/relatedVideos/RelatedVideos.jsx
+++ b/app/javascript/relatedVideos/RelatedVideos.jsx
@@ -1,0 +1,18 @@
+import { h } from 'preact';
+import PropTypes from 'prop-types';
+import { VideoPlayer } from './components/videoPlayer';
+
+export const RelatedVideos = ({ videos }) => (
+  <div>
+    <h1>Related Videos</h1>
+    <div className="related-videos">
+      {JSON.parse(videos).map(video => (
+        <VideoPlayer videoId={video} />
+      ))}
+    </div>
+  </div>
+);
+
+RelatedVideos.propTypes = {
+  videos: PropTypes.string.isRequired,
+};

--- a/app/javascript/relatedVideos/components/videoPlayer.jsx
+++ b/app/javascript/relatedVideos/components/videoPlayer.jsx
@@ -1,0 +1,15 @@
+import { h } from 'preact';
+import PropTypes from 'prop-types';
+
+export const VideoPlayer = ({ videoId }) => (
+  <iframe
+    title={`youtube/${  videoId}`}
+    src={`https://www.youtube.com/embed/${  videoId}`}
+    frameBorder="0"
+    allowFullScreen
+  />
+);
+
+VideoPlayer.propTypes = {
+  videoId: PropTypes.string.isRequired,
+};

--- a/app/services/you_tube_service.rb
+++ b/app/services/you_tube_service.rb
@@ -10,7 +10,7 @@ class YouTubeService
 
   def self.video_info(tags)
     retrieve_videos(tags)[:items].each_with_object({}) do |video, acc|
-      acc[video[:id][:videoId]] = { url: "www.youtube.com/watch?v=#{video[:id][:videoId]}",
+      acc[video[:id][:videoId]] = { videoId: video[:id][:videoId],
                                     title: video[:snippet][:title],
                                     description: video[:snippet][:description],
                                     thumbnail: video[:snippet][:thumbnails][:default][:url],

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -184,6 +184,8 @@
       <% end %>
     <% end %>
     <%= render "articles/org_branding", organization: @organization %>
+    <div id="videos-container" data-videos="<%= %w[pPy0GQJLZUM okMVc3-aCKQ video3].to_json %>"></div>
+    <%= javascript_pack_tag "relatedVideos", defer: true %>
     <%= render "articles/full_comment_area" %>
   </div>
   <% cache("article-bottom-content-#{@article.id}", expires_in: 18.hours) do %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -184,11 +184,11 @@
       <% end %>
     <% end %>
     <%= render "articles/org_branding", organization: @organization %>
-    <div id="videos-container" data-videos="<%= %w[pPy0GQJLZUM okMVc3-aCKQ video3].to_json %>"></div>
+  <% cache("article-bottom-content-#{@article.id}", expires_in: 18.hours) do %>
+    <div id="videos-container" data-videos="<%= @related_videos.keys.to_json %>"></div>
     <%= javascript_pack_tag "relatedVideos", defer: true %>
     <%= render "articles/full_comment_area" %>
   </div>
-  <% cache("article-bottom-content-#{@article.id}", expires_in: 18.hours) do %>
     <% @classic_article = Suggester::Articles::Classic.new(@article, not_ids: [@article.id]).get.first %>
     <% if @classic_article %>
       <%= render "additional_content_boxes/article_box",

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1098,7 +1098,7 @@ ActiveRecord::Schema.define(version: 2020_02_27_214321) do
     t.datetime "last_article_at", default: "2017-01-01 05:00:00"
     t.datetime "last_comment_at", default: "2017-01-01 05:00:00"
     t.datetime "last_followed_at"
-    t.datetime "last_moderation_notification", default: "2017-01-01 05:00:00"
+    t.datetime "last_moderation_notification", default: "2017-01-01 06:00:00"
     t.datetime "last_notification_activity"
     t.string "last_onboarding_page"
     t.datetime "last_sign_in_at"
@@ -1225,6 +1225,7 @@ ActiveRecord::Schema.define(version: 2020_02_27_214321) do
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
   add_foreign_key "page_views", "articles", on_delete: :cascade
   add_foreign_key "podcasts", "users", column: "creator_id"
+  add_foreign_key "pro_memberships", "users"
   add_foreign_key "sponsorships", "organizations"
   add_foreign_key "sponsorships", "users"
   add_foreign_key "tag_adjustments", "articles", on_delete: :cascade

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -89,22 +89,94 @@ Rails.logger.info "4. Creating #{num_articles} Articles"
 
 Article.clear_index!
 
-num_articles.times do |i|
-  tags = []
+# num_articles.times do |i|
+#   tags = []
+#   tags << "discuss" if (i % 3).zero?
+#   tags.concat Tag.order(Arel.sql("RANDOM()")).limit(3).pluck(:name)
+
+#   markdown = <<~MARKDOWN
+#     ---
+#     title:  #{Faker::Book.title} #{Faker::Lorem.sentence(word_count: 2).chomp('.')}
+#     published: true
+#     cover_image: #{Faker::Company.logo}
+#     tags: #{tags.join(', ')}
+#     ---
+
+#     #{Faker::Hipster.paragraph(sentence_count: 2)}
+#     #{Faker::Markdown.random}
+#     #{Faker::Hipster.paragraph(sentence_count: 2)}
+#   MARKDOWN
+
+#   Article.create!(
+#     body_markdown: markdown,
+#     featured: true,
+#     show_comments: true,
+#     user_id: User.order(Arel.sql("RANDOM()")).first.id,
+#   )
+# end
+
+1.times do |i|
+  tags = %w[ruby coding testing]
   tags << "discuss" if (i % 3).zero?
-  tags.concat Tag.order(Arel.sql("RANDOM()")).limit(3).pluck(:name)
 
   markdown = <<~MARKDOWN
     ---
-    title:  #{Faker::Book.title} #{Faker::Lorem.sentence(word_count: 2).chomp('.')}
+    title:  Ruby on Rails — Testing and code quality (part 4)
     published: true
     cover_image: #{Faker::Company.logo}
     tags: #{tags.join(', ')}
     ---
 
-    #{Faker::Hipster.paragraph(sentence_count: 2)}
-    #{Faker::Markdown.random}
-    #{Faker::Hipster.paragraph(sentence_count: 2)}
+    When it comes to unit testing, the more popular ones are MiniTest and RSpec. The first one is now included in Rails as the default framework for tests, so we don’t have to set up anything. However, a lot of people still prefer to work with RSpec, because not only it is compatible with all the other test-related gems, but it also lets us to have tests more readable due to being a Domain Specific Language. Furthermore, on these days, RSpec has a lot of documentation and examples through the web.
+
+  MARKDOWN
+
+  Article.create!(
+    body_markdown: markdown,
+    featured: true,
+    show_comments: true,
+    user_id: User.order(Arel.sql("RANDOM()")).first.id,
+  )
+end
+
+1.times do |i|
+  tags = %w[ruby career webdev]
+  tags << "discuss" if (i % 3).zero?
+
+  markdown = <<~MARKDOWN
+    ---
+    title:  Is Ruby worth learning in 2019?
+    published: true
+    cover_image: #{Faker::Company.logo}
+    tags: #{tags.join(', ')}
+    ---
+
+    Secondly, Ruby on Rails (RoR) is one of the earliest backend web frameworks to hit the scene in late 2005. Despite its OG status, it seems to be falling off the popularity chart. Does that mean you should avoid it, along with the language that was used to build the framework?
+
+  MARKDOWN
+
+  Article.create!(
+    body_markdown: markdown,
+    featured: true,
+    show_comments: true,
+    user_id: User.order(Arel.sql("RANDOM()")).first.id,
+  )
+end
+
+1.times do |i|
+  tags = %w[python ruby career]
+  tags << "discuss" if (i % 3).zero?
+
+  markdown = <<~MARKDOWN
+    ---
+    title:  Should You Learn Python, C, or Ruby to Be a Top Coder?
+    published: true
+    cover_image: #{Faker::Company.logo}
+    tags: #{tags.join(', ')}
+    ---
+
+    Top coders have near limitless prospects when it comes to employment, or even opportunities to succeed in their own startups. In fact, learning to code is fast becoming a necessary life skill, with millions each year taking online and in-person courses to learn Python, Java, and other popular programming languages.
+
   MARKDOWN
 
   Article.create!(

--- a/spec/decorators/article_decorator_spec.rb
+++ b/spec/decorators/article_decorator_spec.rb
@@ -175,12 +175,4 @@ RSpec.describe ArticleDecorator, type: :decorator do
       expect(created_article.description_and_tags).to eq("#{parsed_post_by_string} Tagged with heytag.")
     end
   end
-
-  describe "related_videos" do
-    it "creates a hash from youtube api and cached_tag_list_array" do
-      body_markdown = "---\ntitle: Title\npublished: false\ndescription:\ntags: ruby, coding, testing\n---\n\n"
-      created_article = create_article(body_markdown: body_markdown)
-      expect(created_article.related_videos.class).to eq(Hash)
-    end
-  end
 end

--- a/spec/services/youtube/you_tube_service_spec.rb
+++ b/spec/services/youtube/you_tube_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe YouTubeService, type: :service do
     tag_list = %w[ruby coding testing]
     response = described_class.video_info(tag_list)
     expect(response.length).to eq(3)
-    expect(response.values[0]).to have_key(:url)
+    expect(response.values[0]).to have_key(:videoId)
     expect(response.values[0]).to have_key(:title)
     expect(response.values[0]).to have_key(:description)
     expect(response.values[0]).to have_key(:thumbnail)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds the video component to the article show page.  Video component takes the videoId from the instance variable @related_videos.  This information is also cached for 12 hours to prevent additional api calls.  InstantClick was modified to on mousedown to cut down on api calls as well.

Hard coded article seeds were added for easier local testing.

This will fail Travis CI

- [ ] yes
- [x] no, because they aren't needed - Tests where modified from the original API service to match new keys
- [ ] no, because I need help
